### PR TITLE
Switch default `img` attribute from `srcset` to `src`

### DIFF
--- a/picture_tag.rb
+++ b/picture_tag.rb
@@ -158,7 +158,7 @@ module Jekyll
         # Note: Added backslash+space escapes to bypass markdown parsing of indented code below -WD
         picture_tag = "<picture>\n"\
                       "#{source_tags}"\
-                      "#{markdown_escape * 4}<img srcset=\"#{instance['source_default'][:generated_src]}\" #{html_attr_string}>\n"\
+                      "#{markdown_escape * 4}<img src=\"#{instance['source_default'][:generated_src]}\" #{html_attr_string}>\n"\
                       "#{markdown_escape * 2}</picture>\n"
 
       elsif settings['markup'] == 'img'


### PR DESCRIPTION
Respect the HTML spec:

> The src attribute must be present, and must contain a valid non-empty URL potentially surrounded by spaces […]
> If the srcset attribute is present, the sizes attribute may also be present.

(Source: [WhatWG](https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element))

Improve degradability: even without a polyfill, or with failing JS, older browsers will still display the default image.