### PR TITLE
Handle missing files

### DIFF
--- a/lib/jekyll-picture-tag.rb
+++ b/lib/jekyll-picture-tag.rb
@@ -171,7 +171,12 @@ module Jekyll
     end
 
     def generate_image(instance, site_source, site_dest, image_source, image_dest, baseurl)
-      digest = Digest::MD5.hexdigest(File.read(File.join(site_source, image_source, instance[:src]))).slice!(0..5)
+      begin
+        digest = Digest::MD5.hexdigest(File.read(File.join(site_source, image_source, instance[:src]))).slice!(0..5)
+      rescue Errno::ENOENT
+        warn "Warning:".yellow + " source image #{instance[:src]} is missing."
+        return ""
+      end      
 
       image_dir = File.dirname(instance[:src])
       ext = File.extname(instance[:src])


### PR DESCRIPTION
Show a console warning when a source image cannot be found and carry on
processing rather than stopping