### PR TITLE
Bump Jekyll dependency

### DIFF
--- a/jekyll-picture-tag.gemspec
+++ b/jekyll-picture-tag.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'mini_magick', '~> 3.8.0'
   spec.add_dependency 'fastimage', '~> 1.6.4'
-  spec.add_runtime_dependency 'jekyll', '< 3'
+  spec.add_runtime_dependency 'jekyll', '< 4'
 end


### PR DESCRIPTION
Seems to work fine with Jekyll 3 so far. This PR simply bumps the dependency version in the gemspec