### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Add `jekyll-picture-tag` to your Gemfile in the `:jekyll_plugins` group. For exa
 
 ```ruby
 group :jekyll_plugins do
-  gem 'jekyll-picture-tag', '~> 0.2.3'
+  gem 'jekyll-picture-tag'
 end
 ```
 


### PR DESCRIPTION
Remove version from recommended Gemfile line.

Original was `0.2.3` which forces an old version, not compatible with Jekyll 3. Rather than updating the README on each version bump, remove the version spec in install notes?
