### PR TITLE
Hotfix for Ruby version checking

### DIFF
--- a/jekyll-picture-tag.gemspec
+++ b/jekyll-picture-tag.gemspec
@@ -25,15 +25,15 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
 
-  spec.required_ruby_version = PictureTag::REQUIRED_RUBY_VERSION
+  spec.required_ruby_version = '~> ' + PictureTag::REQUIRED_RUBY_VERSION
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 12.3'
 
-  spec.add_dependency 'fastimage', '~> 2.1'
-  spec.add_dependency 'mini_magick', '~> 4.9'
-  spec.add_dependency 'objective_elements', '~> 1.0.0'
+  spec.add_dependency 'fastimage', '~> 2'
+  spec.add_dependency 'mini_magick', '~> 4'
+  spec.add_dependency 'objective_elements', '~> 1'
 
   spec.add_runtime_dependency 'jekyll', '< 4'
 end

--- a/lib/jekyll-picture-tag/version.rb
+++ b/lib/jekyll-picture-tag/version.rb
@@ -1,4 +1,4 @@
 module PictureTag
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
   REQUIRED_RUBY_VERSION = '2.5'.freeze
 end

--- a/lib/jekyll-picture-tag/version.rb
+++ b/lib/jekyll-picture-tag/version.rb
@@ -1,4 +1,4 @@
 module PictureTag
   VERSION = '1.0.1'.freeze
-  REQUIRED_RUBY_VERSION = '2.5.0'.freeze
+  REQUIRED_RUBY_VERSION = '2.5'.freeze
 end


### PR DESCRIPTION
Fix #93 

Also reduced specificity of various dependency versions to major versions only. There's still some work to be done here, but I'll push this update now to un-break the installation process.