### PR TITLE
Add config parameter to output relative url_prefix instead of absolute.

### DIFF
--- a/lib/jekyll-picture-tag/defaults/global.yml
+++ b/lib/jekyll-picture-tag/defaults/global.yml
@@ -3,6 +3,7 @@ picture:
   source: ''
   output: generated
   suppress_warnings: false
+  relative_url: true
 
 url: ''
 baseurl: ''

--- a/lib/jekyll-picture-tag/instructions/configuration.rb
+++ b/lib/jekyll-picture-tag/instructions/configuration.rb
@@ -63,11 +63,18 @@ module PictureTag
       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       # |     site url     | site path  |    j-p-t dest dir     |
       def url_prefix
-        File.join(
-          PictureTag.config['url'],
-          PictureTag.config['baseurl'],
-          self['picture']['output']
-        )
+        if self['picture']['relative_url']
+          File.join(
+            PictureTag.config['baseurl'],
+            self['picture']['output']
+          )
+        else
+          File.join(
+            PictureTag.config['url'],
+            PictureTag.config['baseurl'],
+            self['picture']['output']
+          )
+        end
       end
     end
   end

--- a/lib/jekyll-picture-tag/instructions/configuration.rb
+++ b/lib/jekyll-picture-tag/instructions/configuration.rb
@@ -63,18 +63,11 @@ module PictureTag
       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       # |     site url     | site path  |    j-p-t dest dir     |
       def url_prefix
-        if self['picture']['relative_url']
-          File.join(
-            PictureTag.config['baseurl'],
-            self['picture']['output']
-          )
-        else
-          File.join(
-            PictureTag.config['url'],
-            PictureTag.config['baseurl'],
-            self['picture']['output']
-          )
-        end
+        File.join(
+          self['picture']['relative_url'] ? '' : PictureTag.config['url'],
+          PictureTag.config['baseurl'],
+          self['picture']['output']
+        )
       end
     end
   end

--- a/readme.md
+++ b/readme.md
@@ -258,6 +258,7 @@ picture:
   source: "assets/images/_fullsize"
   output: "generated" 
   suppress_warnings: false
+  relative_url: true
 ```
 
 #### source
@@ -287,6 +288,14 @@ Picture Tag will never resize an image to be larger than its source). Set this
 value to `true`, and these warnings will not be shown.
 
 Default: `false`
+
+#### relative_url
+
+Whether to use relative (`/generated/test-250by141-195f7d.jpg`) or absolute
+(`http://localhost:4000/generated/test-250by141-195f7d.jpg`) urls in your src
+and srcset attributes.
+
+Default: `true`
 
 **Example \_data/picture.yml**
 


### PR DESCRIPTION
Currently picture-tag is generating absolute URLs for image locations. This causes problems with some plugins, like amp-jekyll, which only work with relative URLs. Also, there really isn't any need for absolute URLs within a website.

Finally, absolute URLs can cause issues with CSP if domains are aliased. An absolute URL from the main site could be blocked by CSP from an aliased site.

The config option `relative_url` is added and the behavior is to only generate relative URLs when set to true. The current absolute URL behavior is the default.