### PR TITLE
Noscript fallback

### DIFF
--- a/examples/_data/picture.yml
+++ b/examples/_data/picture.yml
@@ -74,6 +74,7 @@ markup_presets:
     markup: data_auto
     formats: [webp, original]
     widths: [200, 400, 600, 800]
+    noscript: true # Default: false
     attributes: 
       img: class="lazy"
 

--- a/lib/jekyll-picture-tag/defaults/presets.yml
+++ b/lib/jekyll-picture-tag/defaults/presets.yml
@@ -3,3 +3,4 @@ formats: [original]
 widths: [400, 600, 800, 1000]
 fallback_width: 800
 fallback_format: original
+noscript: false

--- a/lib/jekyll-picture-tag/output_formats/basics.rb
+++ b/lib/jekyll-picture-tag/output_formats/basics.rb
@@ -6,6 +6,23 @@ module PictureTag
     module Basics
       include ObjectiveElements
 
+      # Used for both the fallback image, and for the complete markup.
+      def build_base_img
+        img = SingleTag.new 'img'
+        attributes = PictureTag.html_attributes
+
+        img.attributes << attributes['img']
+        img.attributes << attributes['implicit']
+
+        fallback = build_fallback_image
+
+        add_src(img, fallback.name)
+
+        add_alt(img, attributes['alt'])
+
+        img
+      end
+
       private
 
       def build_srcset(media, format)
@@ -22,23 +39,6 @@ module PictureTag
 
       def build_width_srcset(media, format)
         Srcsets::Width.new(media: media, format: format)
-      end
-
-      # Used for both the fallback image, and for the complete markup.
-      def build_base_img
-        img = SingleTag.new 'img'
-        attributes = PictureTag.html_attributes
-
-        img.attributes << attributes['img']
-        img.attributes << attributes['implicit']
-
-        fallback = build_fallback_image
-
-        add_src(img, fallback.name)
-
-        add_alt(img, attributes['alt'])
-
-        img
       end
 
       # Extracting these functions to their own methods for easy overriding.

--- a/lib/jekyll-picture-tag/output_formats/data_attributes.rb
+++ b/lib/jekyll-picture-tag/output_formats/data_attributes.rb
@@ -24,7 +24,7 @@ module PictureTag
       def build_noscript
         return '' unless PictureTag.preset['noscript']
 
-        "\n" + DoubleTag.new(
+        DoubleTag.new(
           'noscript',
           content: Img.new.build_base_img
         ).to_s

--- a/lib/jekyll-picture-tag/output_formats/data_attributes.rb
+++ b/lib/jekyll-picture-tag/output_formats/data_attributes.rb
@@ -1,7 +1,7 @@
 module PictureTag
   module OutputFormats
-    # Allows us to create JavaScript Library friendly markup, for things like
-    # LazyLoad
+    # This is not an output format, it's a module for use in others. It allows
+    # us to create JavaScript Library friendly markup, for things like LazyLoad
     module DataAttributes
       def to_s
         super + build_noscript
@@ -26,7 +26,7 @@ module PictureTag
 
         "\n" + DoubleTag.new(
           'noscript',
-          content: OutputFormats::Img.new
+          content: Img.new.build_base_img
         ).to_s
       end
     end

--- a/lib/jekyll-picture-tag/output_formats/data_attributes.rb
+++ b/lib/jekyll-picture-tag/output_formats/data_attributes.rb
@@ -3,6 +3,10 @@ module PictureTag
     # Allows us to create JavaScript Library friendly markup, for things like
     # LazyLoad
     module DataAttributes
+      def to_s
+        super + build_noscript
+      end
+
       private
 
       def add_src(element, name)
@@ -15,6 +19,15 @@ module PictureTag
 
       def add_sizes(element, srcset)
         element.attributes << { 'data-sizes' => srcset.sizes } if srcset.sizes
+      end
+
+      def build_noscript
+        return '' unless PictureTag.preset['noscript']
+
+        "\n" + DoubleTag.new(
+          'noscript',
+          content: OutputFormats::Img.new
+        ).to_s
       end
     end
   end

--- a/readme.md
+++ b/readme.md
@@ -337,6 +337,7 @@ in the examples directory.
         markup: data_auto
         formats: [webp, original]
         widths: [200, 400, 600, 800]
+        noscript: true
         attributes: 
           img: class="lazy"
 
@@ -430,6 +431,14 @@ attribute set in a preset.
 The same arguments are available here as in the liquid tag; element names, `alt:`, and `parent:`.
 They follow the format of (element name): 'attribute="value" attribute2="value2"'. (Unescaped double
 quotes cause problems with yml, so surround the entire string with single quotes.)
+
+#### noscript
+
+
+For use with the `data_` output formats. Whether or not to include the `img` output format within a
+`<noscript>` tag after the standard html. Example:
+
+Boolean value, default: `false`
 
 ## Liquid variables
 


### PR DESCRIPTION
Adds option to include a `<noscript>` tag after `data_*` output formats, so disabling javascript doesn't break all your images.

#104 is relevant here as well, though not as severe. It adds a `<p>` tag between the `<img>` and `<noscript>` tags.

Close #102