### PR TITLE
Nomarkdown option

### DIFF
--- a/jekyll-picture-tag.gemspec
+++ b/jekyll-picture-tag.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fastimage', '~> 2'
   spec.add_dependency 'mini_magick', '~> 4'
-  spec.add_dependency 'objective_elements', '~> 1'
+  spec.add_dependency 'objective_elements', '~> 1.1'
 
   spec.add_runtime_dependency 'jekyll', '< 4'
 end

--- a/lib/jekyll-picture-tag/defaults/global.yml
+++ b/lib/jekyll-picture-tag/defaults/global.yml
@@ -4,6 +4,7 @@ picture:
   output: generated
   suppress_warnings: false
   relative_url: true
+  nomarkdown: true
 
 url: ''
 baseurl: ''

--- a/lib/jekyll-picture-tag/instructions.rb
+++ b/lib/jekyll-picture-tag/instructions.rb
@@ -38,17 +38,15 @@ module PictureTag
       @context.registers[:site]
     end
 
+    # Page which tag is called from
+    def page
+      @context.registers[:page]
+    end
+
     # Media query presets. There are no default values, so extracting it to its
     # own class is overkill.
     def media_presets
-      if site.data['picture'] && site.data['picture']['media_presets']
-        site.data['picture']['media_presets']
-      else
-        warn 'Jekyll Picture Tag Warning:'.yellow +
-             ' You are trying to use media queries, but they are not defined.'\
-             ' Set them under the media_presets: key in  _data/picture.yml'
-        {}
-      end
+      site.data.dig('picture', 'media_presets') || {}
     end
 
     # The rest of the application doesn't care where the instruction logic

--- a/lib/jekyll-picture-tag/instructions.rb
+++ b/lib/jekyll-picture-tag/instructions.rb
@@ -43,8 +43,8 @@ module PictureTag
       @context.registers[:page]
     end
 
-    # Media query presets. There are no default values, so extracting it to its
-    # own class is overkill.
+    # Media query presets. It's really just a hash, and there are no default
+    # values, so extracting it to its own class is overkill.
     def media_presets
       site.data.dig('picture', 'media_presets') || {}
     end
@@ -70,6 +70,10 @@ module PictureTag
 
     def build_url(filename)
       @config.build_url(filename)
+    end
+
+    def nomarkdown?
+      @config.nomarkdown?
     end
 
     # Preset forwarding

--- a/lib/jekyll-picture-tag/instructions/configuration.rb
+++ b/lib/jekyll-picture-tag/instructions/configuration.rb
@@ -29,6 +29,10 @@ module PictureTag
         File.join url_prefix, filename
       end
 
+      def nomarkdown?
+        Utils.markdown_page? && self['picture']['nomarkdown']
+      end
+
       private
 
       def build_config

--- a/lib/jekyll-picture-tag/output_formats/basics.rb
+++ b/lib/jekyll-picture-tag/output_formats/basics.rb
@@ -23,6 +23,10 @@ module PictureTag
         img
       end
 
+      def to_s
+        build_markup.to_s
+      end
+
       private
 
       def build_srcset(media, format)

--- a/lib/jekyll-picture-tag/output_formats/basics.rb
+++ b/lib/jekyll-picture-tag/output_formats/basics.rb
@@ -24,10 +24,17 @@ module PictureTag
       end
 
       def to_s
-        build_markup.to_s
+        wrap(base_markup).to_s
       end
 
       private
+
+      # Handles various wrappers around basic markup
+      def wrap(markup)
+        markup = nomarkdown_wrapper(markup.to_s) if PictureTag.nomarkdown?
+
+        markup
+      end
 
       def build_srcset(media, format)
         if PictureTag.preset['pixel_ratios']
@@ -77,8 +84,12 @@ module PictureTag
       end
 
       # Stops kramdown from molesting our output
+      # Must be given a string.
+      #
+      # Kramdown is super picky about the {::nomarkdown} extension-- we have to
+      # strip line breaks or nothing works.
       def nomarkdown_wrapper(content)
-        "{::nomarkdown}#{content}{:/}"
+        "{::nomarkdown}#{content.delete("\n")}{:/nomarkdown}"
       end
     end
   end

--- a/lib/jekyll-picture-tag/output_formats/basics.rb
+++ b/lib/jekyll-picture-tag/output_formats/basics.rb
@@ -71,6 +71,11 @@ module PictureTag
           width: PictureTag.fallback_width
         )
       end
+
+      # Stops kramdown from molesting our output
+      def nomarkdown_wrapper(content)
+        "{::nomarkdown}#{content}{:/}"
+      end
     end
   end
 end

--- a/lib/jekyll-picture-tag/output_formats/data_attributes.rb
+++ b/lib/jekyll-picture-tag/output_formats/data_attributes.rb
@@ -26,11 +26,17 @@ module PictureTag
 
         noscript = DoubleTag.new(
           'noscript',
-          content: Img.new.build_base_img
+          content: Img.new.build_base_img,
+
+          # Markdown fix requires removal of line breaks:
+          oneline: PictureTag.nomarkdown?
         ).to_s
 
         ShelfTag.new(
-          content: [base_content, noscript]
+          content: [base_content, noscript],
+
+          # Markdown fix requires removal of line breaks:
+          oneline: PictureTag.nomarkdown?
         )
       end
     end

--- a/lib/jekyll-picture-tag/output_formats/data_attributes.rb
+++ b/lib/jekyll-picture-tag/output_formats/data_attributes.rb
@@ -3,8 +3,8 @@ module PictureTag
     # This is not an output format, it's a module for use in others. It allows
     # us to create JavaScript Library friendly markup, for things like LazyLoad
     module DataAttributes
-      def to_s
-        super + build_noscript
+      def base_markup
+        build_noscript(super)
       end
 
       private
@@ -21,13 +21,17 @@ module PictureTag
         element.attributes << { 'data-sizes' => srcset.sizes } if srcset.sizes
       end
 
-      def build_noscript
-        return '' unless PictureTag.preset['noscript']
+      def build_noscript(base_content)
+        return base_content unless PictureTag.preset['noscript']
 
-        DoubleTag.new(
+        noscript = DoubleTag.new(
           'noscript',
           content: Img.new.build_base_img
         ).to_s
+
+        ShelfTag.new(
+          content: [base_content, noscript]
+        )
       end
     end
   end

--- a/lib/jekyll-picture-tag/output_formats/img.rb
+++ b/lib/jekyll-picture-tag/output_formats/img.rb
@@ -9,7 +9,7 @@ module PictureTag
         build_srcset(nil, PictureTag.preset['formats'].first)
       end
 
-      def build_markup
+      def base_markup
         img = build_base_img
 
         add_srcset(img, srcset)

--- a/lib/jekyll-picture-tag/output_formats/img.rb
+++ b/lib/jekyll-picture-tag/output_formats/img.rb
@@ -9,7 +9,7 @@ module PictureTag
         build_srcset(nil, PictureTag.preset['formats'].first)
       end
 
-      def to_s
+      def build_markup
         img = build_base_img
 
         add_srcset(img, srcset)
@@ -17,7 +17,7 @@ module PictureTag
 
         img.attributes << PictureTag.html_attributes['parent']
 
-        img.to_s
+        img
       end
     end
   end

--- a/lib/jekyll-picture-tag/output_formats/picture.rb
+++ b/lib/jekyll-picture-tag/output_formats/picture.rb
@@ -47,7 +47,7 @@ module PictureTag
         source
       end
 
-      def to_s
+      def build_markup
         picture = DoubleTag.new(
           'picture',
           attributes: PictureTag.html_attributes['picture'],
@@ -56,7 +56,7 @@ module PictureTag
 
         picture.attributes << PictureTag.html_attributes['parent']
 
-        picture.to_s
+        picture
       end
     end
   end

--- a/lib/jekyll-picture-tag/output_formats/picture.rb
+++ b/lib/jekyll-picture-tag/output_formats/picture.rb
@@ -47,7 +47,7 @@ module PictureTag
         source
       end
 
-      def build_markup
+      def base_markup
         picture = DoubleTag.new(
           'picture',
           attributes: PictureTag.html_attributes['picture'],

--- a/lib/jekyll-picture-tag/output_formats/picture.rb
+++ b/lib/jekyll-picture-tag/output_formats/picture.rb
@@ -51,7 +51,10 @@ module PictureTag
         picture = DoubleTag.new(
           'picture',
           attributes: PictureTag.html_attributes['picture'],
-          content: build_sources << build_base_img
+          content: build_sources << build_base_img,
+
+          # Markdown fix requires removal of line breaks:
+          oneline: PictureTag.nomarkdown?
         )
 
         picture.attributes << PictureTag.html_attributes['parent']

--- a/lib/jekyll-picture-tag/utils.rb
+++ b/lib/jekyll-picture-tag/utils.rb
@@ -51,7 +51,7 @@ module PictureTag
     end
 
     # Returns whether or not the current page is a markdown file.
-    def markdown_page?
+    def self.markdown_page?
       ext = File.extname(PictureTag.page['name'])
 
       ext.casecmp('.md').zero? || ext.casecmp('.markdown').zero?

--- a/lib/jekyll-picture-tag/utils.rb
+++ b/lib/jekyll-picture-tag/utils.rb
@@ -49,5 +49,12 @@ module PictureTag
 
       formats * source_images
     end
+
+    # Returns whether or not the current page is a markdown file.
+    def markdown_page?
+      ext = File.extname(PictureTag.page['name'])
+
+      ext.casecmp('.md').zero? || ext.casecmp('.markdown').zero?
+    end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -259,6 +259,7 @@ picture:
   output: "generated" 
   suppress_warnings: false
   relative_url: true
+  nomarkdown: true
 ```
 
 #### source
@@ -282,18 +283,33 @@ changed it.
 
 #### suppress_warnings
 
-Jekyll Picture Tag will warn you in a few different scenarios, such as when your
-base image is smaller than one of the sizes in your preset. (Note that Jekyll
-Picture Tag will never resize an image to be larger than its source). Set this
-value to `true`, and these warnings will not be shown.
+Jekyll Picture Tag will warn you in a few different scenarios, such as when your base image is
+smaller than one of the sizes in your preset. (Note that Jekyll Picture Tag will never resize an
+image to be larger than its source). Set this value to `true`, and these warnings will not be shown.
 
 Default: `false`
 
 #### relative_url
 
 Whether to use relative (`/generated/test-250by141-195f7d.jpg`) or absolute
-(`http://localhost:4000/generated/test-250by141-195f7d.jpg`) urls in your src
-and srcset attributes.
+(`http://localhost:4000/generated/test-250by141-195f7d.jpg`) urls in your src and srcset attributes.
+
+Default: `true`
+
+#### nomarkdown
+
+Whether or not to surround j-p-t's output with a `{::nomarkdown}..{:/nomarkdown}` block when called
+from within a markdown file. This one requires some explanation:
+
+Under certain circumstances, Kramdown (Jekyll's default markdown parser) will get confused by HTML
+and will subsequently butcher it. One instance is when you wrap a block level element (such as a
+`<picture>`) within a span level element (such as an anchor tag). This flag will fix that issue.
+
+Kramdown is finicky about when it will or won't listen to the `nomarkdown` option, depending on the
+line breaks before, after, and within the block. The most general solution I've found is to remove
+all line breaks from j-p-t's output, giving the whole shebang on one line. It makes for ugly markup,
+but it's pretty much only ever seen by the browser anyway. If you know a better way to accomplish
+this, I'm all ears!
 
 Default: `true`
 


### PR DESCRIPTION
Fix #104 

Add `{::nomarkdown}` block to j-p-t's output, along with accompanying logic, default settings, and documentation. 

Update to a new version of objective elements, because it makes handling sibling elements a bit easier.