### PR TITLE
fix exception when called from posts

### DIFF
--- a/lib/jekyll-picture-tag/utils.rb
+++ b/lib/jekyll-picture-tag/utils.rb
@@ -52,7 +52,8 @@ module PictureTag
 
     # Returns whether or not the current page is a markdown file.
     def self.markdown_page?
-      ext = File.extname(PictureTag.page['name'])
+      page_name = PictureTag.page['name']
+      ext = page_name ? File.extname(page_name) : PictureTag.page['ext']
 
       ext.casecmp('.md').zero? || ext.casecmp('.markdown').zero?
     end


### PR DESCRIPTION
Jekyll provides a different context object depending on where it's called from. When called from a normal page, it has a `name` property. When called from a post, it doesn't have a `name`, but it has an `ext`. We have to use the one that exists.

Fix #108 