### PR TITLE
Change logic for detecting page/post file type

### DIFF
--- a/lib/jekyll-picture-tag/utils.rb
+++ b/lib/jekyll-picture-tag/utils.rb
@@ -52,9 +52,7 @@ module PictureTag
 
     # Returns whether or not the current page is a markdown file.
     def self.markdown_page?
-      page_name = PictureTag.page['name']
-      ext = page_name ? File.extname(page_name) : PictureTag.page['ext']
-
+      ext = PictureTag.page['ext']
       ext.casecmp('.md').zero? || ext.casecmp('.markdown').zero?
     end
 

--- a/lib/jekyll-picture-tag/utils.rb
+++ b/lib/jekyll-picture-tag/utils.rb
@@ -52,7 +52,10 @@ module PictureTag
 
     # Returns whether or not the current page is a markdown file.
     def self.markdown_page?
-      ext = PictureTag.page['ext']
+      page_name = PictureTag.page['name']
+      page_ext = PictureTag.page['ext']
+      ext = page_ext ? page_ext : File.extname(page_name)
+
       ext.casecmp('.md').zero? || ext.casecmp('.markdown').zero?
     end
 


### PR DESCRIPTION
I was playing with a [generator](https://jekyllrb.com/docs/plugins/generators/)
and found that `page['name']` is handled a bit differently when they're called. In the
example (and others I've seen) `@name` is set to the output file name. Usually `index.html`.
However, the input file is not a `.html` file. I noticed that `page['ext']` still shows the correct
file type for the input even with `@name` being explicitly set.

The current logic of checking `page['name']` then falling back to `page['ext']`
is causing j-p-t to mis-detect markdown files when going through a generator.
I changed this to try `page['ext']` first and then fallback to `page['name']`.

What I've found is:
1. A page has `page['name']` and no `page['ext']`
2. A post has `page['ext']` and no `page['name']`
3. A post going through a generator has `page['ext']` and `page['name']`
   but `page['name']` is the generator's output file name not the input file.

Here's the test case I worked up. I think it has full coverage of different ways
content could be fed to j-p-t and similar plugins.

```
jekyll new myblog4
cd myblog4
mkdir images
mkdir _data
mkdir _layouts
mkdir _plugins
cp ~/s.png images/
```

Gemfile
```
source "https://rubygems.org"
gem "jekyll", "~> 3.8.5"
gem "minima", "~> 2.0"
group :jekyll_plugins do
  # My local checkout.
  gem 'jekyll-picture-tag', :path => './vendor/jekyll-picture-tag'
end
gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
gem "wdm", "~> 0.1.0" if Gem.win_platform?

```

_config.yml
```
title: Your awesome title
email: your-email@example.com
description: >- # this means to ignore newlines until "baseurl:"
  Write an awesome description for your new site here. You can edit this
  line in _config.yml. It will appear in your document head meta (for
  Google search results) and in your feed.xml site description.
baseurl: "" # the subpath of your site, e.g. /blog
url: "" # the base hostname & protocol for your site, e.g. http://example.com
twitter_username: jekyllrb
github_username:  jekyll
markdown: kramdown
theme: minima
plugins:
  - jekyll-picture-tag
picture:
  source: "images"
  output: "images/generated"
```

_data/picture.yml
```
markup_presets:
  default:
    markup: data_picture
    formats: [webp, original]
    noscript: true
```

_layouts/gens.html
```
---
layout: gens
---
<!doctype html>
<html>
    <body>
        <div>
            {{ content | markdownify }}
        </div>
    </body>
</html>
```

_plugins/gens.rb
```module Jekyll
  class GensPage < Page
    def initialize(site, base, dir, post)
      @site = site
      @base = base
      @dir = dir
      @name = 'index.html'

      self.process(@name)
      self.read_yaml(File.join(base, '_layouts'), 'gens.html')

      self.content = post.content
      self.data['body'] = (Liquid::Template.parse post.content).render site.site_payload

      self.data = post.data.merge(self.data)
    end
  end

  class GensPageGenerator < Generator
    priority :low
    safe true

    def generate(site)
        dir = 'gens'
        site.posts.docs.each do |post|
          site.pages << GensPage.new(site, site.source, File.join(dir, post.id), post)
        end
    end
  end
end
```

_posts/2019-02-09-html-post.html
```
{% picture s.png %}
```

_posts/2019-02-09-welcome-to-jekyll.markdown
```
---
layout: post
title:  "Welcome to Jekyll!"
date:   2019-02-09 12:01:30 -0500
categories: jekyll update
---

[{% picture s.png %}](/images/s.png)
```

about.md
```
---
layout: page
title: About
permalink: /about/
---
[{% picture s.png %}](/images/s.png)
```

I put these lines in the `markdown_page?` function in "lib/jekyll-picture-tag/utils.rb"
to output what I described above with `page['name']` and `page['ext']`

```
puts "p_url:  #{PictureTag.page['url']}"
puts "p_name: #{PictureTag.page['name']}"
puts "p_ext:  #{PictureTag.page['ext']}"
```

When I build I get this output:

```
$ jekyll serve
Configuration file: /Users/john/Tmp/myblog4/_config.yml
            Source: /Users/john/Tmp/myblog4
       Destination: /Users/john/Tmp/myblog4/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
       Jekyll Feed: Generating feed for posts
Generating new image file: s-400by53-70cbfd.webp
Generating new image file: s-600by79-70cbfd.webp
Generating new image file: s-800by106-70cbfd.webp
Generating new image file: s-1000by132-70cbfd.webp
Generating new image file: s-400by53-70cbfd.png
Generating new image file: s-600by79-70cbfd.png
Generating new image file: s-800by106-70cbfd.png
Generating new image file: s-1000by132-70cbfd.png
p_url:  /2019/02/09/html-post.html
p_name: 
p_ext:  .html

p_url:  /2019/02/09/html-post.html
p_name: 
p_ext:  .html

p_url:  /2019/02/09/html-post.html
p_name: 
p_ext:  .html

p_url:  /2019/02/09/html-post.html
p_name: 
p_ext:  .html

p_url:  /jekyll/update/2019/02/09/welcome-to-jekyll.html
p_name: 
p_ext:  .markdown

p_url:  /jekyll/update/2019/02/09/welcome-to-jekyll.html
p_name: 
p_ext:  .markdown

p_url:  /jekyll/update/2019/02/09/welcome-to-jekyll.html
p_name: 
p_ext:  .markdown

p_url:  /jekyll/update/2019/02/09/welcome-to-jekyll.html
p_name: 
p_ext:  .markdown

p_url:  /jekyll/update/2019/02/09/welcome-to-jekyll.html
p_name: 
p_ext:  .markdown

p_url:  /jekyll/update/2019/02/09/welcome-to-jekyll.html
p_name: 
p_ext:  .markdown

p_url:  /jekyll/update/2019/02/09/welcome-to-jekyll.html
p_name: 
p_ext:  .markdown

p_url:  /jekyll/update/2019/02/09/welcome-to-jekyll.html
p_name: 
p_ext:  .markdown

p_url:  /about/
p_name: about.md
p_ext:  

p_url:  /about/
p_name: about.md
p_ext:  

p_url:  /about/
p_name: about.md
p_ext:  

p_url:  /about/
p_name: about.md
p_ext:  

p_url:  /gens/2019/02/09/html-post/
p_name: index.html
p_ext:  .html

p_url:  /gens/2019/02/09/html-post/
p_name: index.html
p_ext:  .html

p_url:  /gens/2019/02/09/html-post/
p_name: index.html
p_ext:  .html

p_url:  /gens/2019/02/09/html-post/
p_name: index.html
p_ext:  .html

p_url:  /gens/jekyll/update/2019/02/09/welcome-to-jekyll/
p_name: index.html
p_ext:  .markdown

p_url:  /gens/jekyll/update/2019/02/09/welcome-to-jekyll/
p_name: index.html
p_ext:  .markdown

p_url:  /gens/jekyll/update/2019/02/09/welcome-to-jekyll/
p_name: index.html
p_ext:  .markdown

p_url:  /gens/jekyll/update/2019/02/09/welcome-to-jekyll/
p_name: index.html
p_ext:  .markdown

p_url:  /2019/02/09/html-post.html
p_name: 
p_ext:  .html

p_url:  /2019/02/09/html-post.html
p_name: 
p_ext:  .html

p_url:  /2019/02/09/html-post.html
p_name: 
p_ext:  .html

p_url:  /2019/02/09/html-post.html
p_name: 
p_ext:  .html

                    done in 0.986 seconds.
 Auto-regeneration: enabled for '/Users/john/Tmp/myblog4'
    Server address: http://127.0.0.1:4000/
  Server running... press ctrl-c to stop.
```