### PR TITLE
duplicate targets in widths check

### DIFF
--- a/lib/jekyll-picture-tag/srcsets/basics.rb
+++ b/lib/jekyll-picture-tag/srcsets/basics.rb
@@ -57,7 +57,7 @@ module PictureTag
           " at least one size in the set #{targets}. Will not enlarge."
         )
 
-        small_targets = targets.delete_if { |t| t >= image_width }
+        small_targets = targets.dup.delete_if { |t| t >= image_width }
 
         small_targets.push image_width
 


### PR DESCRIPTION
fix #115 

The issue was that when I checked the set of widths to generate, I was inadvertently operating on the original set rather than making a copy. Apparently this persists between picture tag instances, I had assumed it would not.