### PR TITLE
Fix 116

### DIFF
--- a/jekyll-picture-tag.gemspec
+++ b/jekyll-picture-tag.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fastimage', '~> 2'
   spec.add_dependency 'mini_magick', '~> 4'
   spec.add_dependency 'objective_elements', '~> 1.1'
+  spec.add_dependency 'mime-types', '~> 3'
 
   spec.add_runtime_dependency 'jekyll', '< 4'
 end

--- a/lib/jekyll-picture-tag/srcsets/basics.rb
+++ b/lib/jekyll-picture-tag/srcsets/basics.rb
@@ -9,6 +9,7 @@ module PictureTag
     #   pixels.
     module Basics
       require 'fastimage'
+      require 'mime-types'
       attr_reader :media, :source_image
 
       def initialize(media:, format:)
@@ -27,7 +28,7 @@ module PictureTag
       # Allows us to add a type attribute to whichever element contains this
       # srcset.
       def mime_type
-        mime_types[@format]
+        MIME::Types.type_for(@format).first.to_s
       end
 
       # Some srcsets have them, for those that don't return nil.
@@ -72,17 +73,6 @@ module PictureTag
         )
       end
 
-      # Hardcoding these isn't ideal, but I'm not pulling in a new dependency
-      # for 9 lines of easy code.
-      def mime_types
-        {
-          'gif'  => 'image/gif',
-          'jpg'  => 'image/jpeg',
-          'jpeg' => 'image/jpeg',
-          'png'  => 'image/png',
-          'webp' => 'image/webp'
-        }
-      end
     end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -567,6 +567,12 @@ To use a multiplier based srcset, set `pixel_ratios` and `base_width`.
 
   *Default*: `original`
 
+  *Supported Formats:*
+  * jpg/jpeg
+  * png
+  * gif
+  * webp
+
   Array (yml sequence) of the image formats you'd like to generate, in decreasing order
   of preference. Browsers will render the first format they find and understand, so if you put jpg
   before webp, your webp images will never be used. `original` does what you'd expect. To supply

--- a/readme.md
+++ b/readme.md
@@ -567,11 +567,14 @@ To use a multiplier based srcset, set `pixel_ratios` and `base_width`.
 
   *Default*: `original`
 
-  *Supported Formats:*
+  *Supported formats are anything which imagemagick supports, including the
+  following:*
   * jpg/jpeg
   * png
   * gif
   * webp
+  * jxr
+  * jp2
 
   Array (yml sequence) of the image formats you'd like to generate, in decreasing order
   of preference. Browsers will render the first format they find and understand, so if you put jpg


### PR DESCRIPTION
This implements support for all image types that imagemagick supports. It was an easy change, all I needed to add was a mime type lookup that supported more than the 5 values I'd hardcoded in previous versions. 