### PR TITLE
Updated gem to allow the use of Jekyll 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 .idea
 jekyll-picture-tag.iml
+*.gem

--- a/jekyll-picture-tag.gemspec
+++ b/jekyll-picture-tag.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'objective_elements', '~> 1.1'
   spec.add_dependency 'mime-types', '~> 3'
 
-  spec.add_runtime_dependency 'jekyll', '< 4'
+  spec.add_runtime_dependency 'jekyll', '< 5'
 end

--- a/lib/jekyll-picture-tag/version.rb
+++ b/lib/jekyll-picture-tag/version.rb
@@ -1,3 +1,3 @@
 module PictureTag
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.3.0'.freeze
 end


### PR DESCRIPTION
I've updated the gem version to 1.3.0 and updated the Jekyll dependency to allow the use of Jekyll version <5. I've tested locally and works as expected. We should add some tests to check these changes don't affect anything obscure; but my knowledge of Ruby/gems is limited sadly :/

https://github.com/robwierzbowski/jekyll-picture-tag/issues/131